### PR TITLE
[WIP] fix(install): manifest must specify the zip file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,8 +11,8 @@
       {
         "version": "1.0.0",
         "targetAbi": "10.10.0.0",
-        "sourceUrl": "https://github.com/bvolvy/CustomLogoPlugin/releases/tag/v1.0.0",
-        "checksum": "d026126bede7c33e6c26c3ae826a8f774e140319c57b38b7bd50ff3ba3890b55",
+        "sourceUrl": "https://github.com/bvolvy/CustomLogoPlugin/archive/refs/tags/v1.0.0.zip",
+        "checksum": "C9406B27180C144D9D3F9EF7D9340666",
         "timestamp": "2025-04-30T23:00:00Z"
       }
     ]


### PR DESCRIPTION
This pr changes the reference of the checksum file and updates the download url for the plugin to match the requirements of jellyfin.
![image](https://github.com/user-attachments/assets/d9b533da-944d-4361-9dbe-88e5c8c7a43c)

Maybe there's a need of create another version for older users? Can you check if the changes are working in previous versions?

Tested in: 
Jellyfin version: 10.10.7

fix #1